### PR TITLE
#70 Not throwing exception when switch not handles MessagePropertyName

### DIFF
--- a/Analogy.LogViewer.Log4Net.UnitTests/Analogy.LogViewer.Log4Net.UnitTests.csproj
+++ b/Analogy.LogViewer.Log4Net.UnitTests/Analogy.LogViewer.Log4Net.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
@@ -11,6 +11,10 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="coverlet.collector" Version="3.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Analogy.LogViewer.Log4Net\Analogy.LogViewer.Log4Net.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Analogy.LogViewer.Log4Net.UnitTests/RegexParserShould.cs
+++ b/Analogy.LogViewer.Log4Net.UnitTests/RegexParserShould.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Analogy.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Analogy.LogViewer.Log4Net.UnitTests
+{
+    [TestClass]
+    public class RegexParserShould
+    {
+        [TestMethod]
+        public void Parse_To_Log_Message()
+        {
+            //var regEx = @"(?<Date>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) \[(?<Thread>\d+)\] (?<Level>.*)   (?<Source>.*) - (?<Text>.*)";
+            var regEx = @"(?<Date>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3})\s\[(?<Thread>\d+)\]\s(?<Level>.*)\s(?<Source>.*)\s-\s(?<Text>.*)";
+            var testString = "2021-05-06 15:00:00,555 [14] INFO   MyClass.Something - Resolving IDiscoverable";
+            var dateTimeFormat = "yyyy-MM-dd HH:mm:ss,fff";
+
+            RegexPattern p = new RegexPattern(regEx, dateTimeFormat, "");
+            bool valid = RegexParser.CheckRegex(testString, p, out AnalogyLogMessage m);
+
+            Assert.IsTrue(valid);
+
+        }
+
+    }
+}

--- a/Analogy.LogViewer.Log4Net/RegexParser.cs
+++ b/Analogy.LogViewer.Log4Net/RegexParser.cs
@@ -12,8 +12,8 @@ namespace Analogy.LogViewer.Log4Net
 {
     public class RegexParser
     {
-        private AnalogyLogMessage _current;
-        private RegexPattern _lastUsedPattern;
+        private AnalogyLogMessage? _current;
+        private RegexPattern? _lastUsedPattern;
         private readonly List<AnalogyLogMessage> _messages = new List<AnalogyLogMessage>();
         private readonly List<RegexPattern> _logPatterns;
         private readonly bool updateUIAfterEachParsedLine;

--- a/Analogy.LogViewer.Log4Net/RegexParser.cs
+++ b/Analogy.LogViewer.Log4Net/RegexParser.cs
@@ -191,6 +191,15 @@ namespace Analogy.LogViewer.Log4Net
                                 }
 
                                 continue;
+                            case AnalogyLogMessagePropertyName.MachineName:
+                                m.MachineName = value;
+                                break;
+                            case AnalogyLogMessagePropertyName.RawText:
+                                m.RawText = value;
+                                break;
+                            case AnalogyLogMessagePropertyName.RawTextType:
+                                m.RawTextType = AnalogyRowTextType.PlainText;
+                                break;
                             default:
                                 throw new ArgumentOutOfRangeException();
                         }
@@ -337,6 +346,17 @@ namespace Analogy.LogViewer.Log4Net
                                 }
 
                                 break;
+                            case AnalogyLogMessagePropertyName.MachineName:
+                                m.MachineName = value;
+                                break;
+                            case AnalogyLogMessagePropertyName.RawText:
+                                m.RawText = value;
+                                break;
+                            case AnalogyLogMessagePropertyName.RawTextType:
+                                m.RawTextType = AnalogyRowTextType.PlainText;
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException(); 
                         }
                     }
 

--- a/Analogy.LogViewer.Log4Net/RegexParser.cs
+++ b/Analogy.LogViewer.Log4Net/RegexParser.cs
@@ -337,8 +337,6 @@ namespace Analogy.LogViewer.Log4Net
                                 }
 
                                 break;
-                            default:
-                                throw new ArgumentOutOfRangeException();
                         }
                     }
 


### PR DESCRIPTION
I've removed the default throw from as agreed in https://github.com/Analogy-LogViewer/Analogy.LogViewer.Log4Net/issues/70
